### PR TITLE
cmds/core/netstat: add simple integration test

### DIFF
--- a/cmds/core/netstat/integration_test.go
+++ b/cmds/core/netstat/integration_test.go
@@ -1,0 +1,215 @@
+// Copyright 2021-2025 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build (!tinygo || tinygo.enable) && !race
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Netflix/go-expect"
+	"github.com/hugelgupf/vmtest/qemu"
+	"github.com/hugelgupf/vmtest/qemu/qnetwork"
+	"github.com/hugelgupf/vmtest/scriptvm"
+	"github.com/u-root/mkuimage/uimage"
+)
+
+func TestNetstat(t *testing.T) {
+	tests := []struct {
+		cmd string
+		exp expect.ExpectOpt
+	}{
+		{
+			cmd: "netstat -I lo",
+			exp: expect.All(
+				expect.String("Kernel Interface table"),
+				expect.String("Iface            MTU      Rx-OK    Rx-ERR   Rx-DRP   Rx-OVR   TX-OK    TX-ERR   TX-DRP   TX-OVR   Flg"),
+				expect.String("lo               65536    8        0        0        0        8        0        0        0        LUR"),
+			),
+		},
+		{
+			cmd: "netstat -r",
+			exp: expect.All(
+				expect.String("Kernel IP routing table"),
+				expect.String("Destination      Gateway          Genmask          Flags    MSS Window  irrt Iface"),
+				expect.String("default          0.0.0.0          0.0.0.0          U        0   0          0 eth0"),
+				expect.String("192.168.0.0      0.0.0.0          255.255.255.0    U        0   0          0 eth0"),
+			),
+		},
+		{
+			cmd: "netstat -s",
+			exp: expect.All(
+				expect.String("ip:"),
+				expect.String("Forwarding is 2"),
+				expect.String("Default TTL is 64"),
+				expect.String("13 total packets received"),
+				expect.String("0 forwarded"),
+				expect.String("0 incoming packets discarded"),
+				expect.String("13 incoming packets delivered"),
+				expect.String("13 requests sent out"),
+				expect.String("icmp:"),
+				expect.String("6 ICMP messages received"),
+				expect.String("0 input ICMP message failed"),
+				expect.String("6 ICMP messages sent"),
+				expect.String("0 ICMP messages failed"),
+				expect.String("Input historam:"),
+				expect.String("destination unreachable: 4"),
+				expect.String("echo requests: 1"),
+				expect.String("echo replies: 1"),
+				expect.String("Output historam:"),
+				expect.String("IcmpMsg:"),
+				expect.String("InType3: 4"),
+				expect.String("OutType3: 4"),
+				expect.String("tcp:"),
+				expect.String("RtoAlgorithm: 1"),
+				expect.String("RtoMin: 200"),
+				expect.String("RtoMax: 120000"),
+				expect.String("MaxConn: -1"),
+				expect.String("2 active connection openings"),
+				expect.String("2 passive connection openings"),
+				expect.String("0 failed connection attempts"),
+				expect.String("0 connection resets received"),
+				expect.String("4 connections established"),
+				expect.String("6 segments received"),
+				expect.String("6 resets sent"),
+				expect.String("0 segments retransmitted"),
+				expect.String("0 bad segments received"),
+				expect.String("0 segments sent out"),
+				expect.String("udp:"),
+				expect.String("0 packets received"),
+				expect.String("4 packets to unknown port received"),
+				expect.String("0 packet receive errors"),
+				expect.String("4 packets sent"),
+				expect.String("0 receive buffer errors"),
+				expect.String("0 send buffer errors"),
+				expect.String("tcpExt:"),
+				expect.String("2 acknowledgments not containing data payload received"),
+				expect.String("TCPDelivered: 2"),
+				expect.String("ipExt:"),
+				expect.String("InOctets: 1068"),
+				expect.String("OutOctets: 1068"),
+				expect.String("InNoECTPkts: 13"),
+			),
+		},
+		{
+			cmd: "netstat -4 --tcp --all --numeric",
+			exp: expect.All(
+				expect.String("Proto  Recv-Q Send-Q Local Address                       Foreign Address                     State"),
+				expect.String("tcp         0      0 127.0.0.1:5005                      0.0.0.0:0                           LISTEN"),
+				expect.RegexpPattern(`tcp\s+0\s+0\s+127\.0\.0\.1:5005\s+127\.0\.0\.1:\d+\s+ESTABLISHED`),
+				expect.RegexpPattern(`tcp\s+0\s+0\s+127\.0\.0\.1:\d+\s+127\.0\.0\.1:5005\s+ESTABLISHED`),
+			),
+		},
+		{
+			cmd: "netstat -4 --udp --all --numeric",
+			exp: expect.All(
+				expect.String("Proto  Recv-Q Send-Q Local Address                       Foreign Address                     State"),
+				expect.RegexpPattern(`udp\s+0\s+0\s+127\.0\.0\.1:\d+\s+127\.0\.0\.1:5005\s+ESTABLISHED`),
+				expect.String("udp         0      0 127.0.0.1:5005                      0.0.0.0:0                           CLOSE"),
+			),
+		},
+		{
+			cmd: "netstat -6 --tcp --all --numeric",
+			exp: expect.All(
+				expect.String("Proto  Recv-Q Send-Q Local Address                       Foreign Address                     State"),
+				expect.String("tcp6        0      0 ::1:5005                            :::0                                LISTEN"),
+				expect.RegexpPattern(`tcp6\s+0\s+0\s+::1:5005\s+::1:\d+\s+ESTABLISHED`),
+				expect.RegexpPattern(`tcp6\s+0\s+0\s+::1:\d+\s+::1:5005\s+ESTABLISHED`),
+			),
+		},
+		{
+			cmd: "netstat -6 --udp --all --numeric",
+			exp: expect.All(
+				expect.String("Proto  Recv-Q Send-Q Local Address                       Foreign Address                     State"),
+				expect.RegexpPattern(`udp6\s+0\s+0\s+::1:\d+\s+::1:5005\s+ESTABLISHED`),
+				expect.String("udp6        0      0 ::1:5005                            :::0                                CLOSE"),
+			),
+		},
+		{
+			cmd: "netstat --unix --all",
+			exp: expect.All(
+				expect.String("Active sockets in the UNIX domain"),
+				expect.String("Proto   RefCnt  Flags   Type      State           I-Node    Path"),
+				expect.RegexpPattern(`unix\s+3\s+\[\]\s+STREAM\s+CONNECTED\s+\d+\s+stream\.sock`),
+				expect.RegexpPattern(`unix\s+2\s+\[\]\s+DGRAM\s+CONNECTED\s+\d+`),
+				expect.RegexpPattern(`unix\s+3\s+\[\]\s+DGRAM\s+CONNECTED\s+\d+\s+datagram\.sock`),
+				expect.RegexpPattern(`unix\s+2\s+\[ACC\]\s+STREAM\s+LISTENING\s+\d+\s+stream\.sock`),
+				expect.RegexpPattern(`unix\s+3\s+\[\]\s+STREAM\s+CONNECTED\s+\d+`),
+			),
+		},
+	}
+
+	var script strings.Builder
+	fmt.Fprint(&script, `
+		ip addr add 192.168.0.1/24 dev eth0
+		ip link set eth0 up
+		ip route add 0.0.0.0/0 dev eth0
+		ping -c 1 192.168.0.1
+
+		{
+			echo 127.0.0.1 localhost4
+			echo ::1 localhost6
+		} >>/etc/hosts
+
+		{
+			netcat --keep-open --listen -4                 127.0.0.1 5005 &
+			netcat --keep-open --listen -4         --udp   127.0.0.1 5005 &
+			netcat --keep-open --listen -6                 ::1       5005 &
+			netcat --keep-open --listen -6         --udp   ::1       5005 &
+			netcat --keep-open --listen --unixsock         stream.sock    &
+			netcat --keep-open --listen --unixsock --udp   datagram.sock  &
+		} </dev/null >/dev/null
+		sleep 2
+
+		sleep 3600 \
+		| {
+			netcat -4                 127.0.0.1 5005 &
+			netcat -4         --udp   127.0.0.1 5005 &
+			netcat -6                 ::1       5005 &
+			netcat -6         --udp   ::1       5005 &
+			netcat --unixsock         stream.sock    &
+			netcat --unixsock --udp   datagram.sock  &
+		} >/dev/null &
+		sleep 2
+	`)
+	for _, test := range tests {
+		fmt.Fprintln(&script, test.cmd)
+	}
+
+	vm := scriptvm.Start(t, "vm", script.String(),
+		scriptvm.WithUimage(
+			uimage.WithBusyboxCommands(
+				"github.com/u-root/u-root/cmds/core/echo",
+				"github.com/u-root/u-root/cmds/core/ip",
+				"github.com/u-root/u-root/cmds/core/netcat",
+				"github.com/u-root/u-root/cmds/core/ping",
+				"github.com/u-root/u-root/cmds/core/sleep",
+			),
+			uimage.WithCoveredCommands(
+				"github.com/u-root/u-root/cmds/core/netstat",
+			),
+		),
+		scriptvm.WithQEMUFn(
+			qemu.WithVMTimeout(2*time.Minute),
+			qnetwork.HostNetwork("192.168.0.0/24"),
+		),
+	)
+
+	for _, test := range tests {
+		t.Run(test.cmd, func(t *testing.T) {
+			if _, err := vm.Console.Expect(test.exp); err != nil {
+				t.Errorf("VM output did not match expectations: %v", err)
+			}
+		})
+	}
+
+	if err := vm.Wait(); err != nil {
+		t.Errorf("Wait: %v", err)
+	}
+	_ = vm.Wait()
+}

--- a/pkg/netcat/config.go
+++ b/pkg/netcat/config.go
@@ -178,6 +178,9 @@ func (c *Config) Address() (string, error) {
 			}
 		}
 
+		if c.ProtocolOptions.SocketType == SOCKET_TYPE_UNIX || c.ProtocolOptions.SocketType == SOCKET_TYPE_UDP_UNIX {
+			return address, nil
+		}
 		return address + ":" + strconv.FormatUint(c.Port, 10), nil
 	default:
 		return "", fmt.Errorf("invalid connection mode %v", c.ConnectionMode)

--- a/pkg/netcat/config.go
+++ b/pkg/netcat/config.go
@@ -147,7 +147,7 @@ func (c *Config) Address() (string, error) {
 
 			if c.ConnectionModeOptions.CurrentPort != 0 {
 				port := c.ConnectionModeOptions.CurrentPort
-				return c.Host + ":" + strconv.FormatUint(port, 10), nil
+				return net.JoinHostPort(c.Host, strconv.FormatUint(port, 10)), nil
 			}
 
 			return net.JoinHostPort(c.Host, strconv.FormatUint(c.Port, 10)), nil

--- a/pkg/netcat/config.go
+++ b/pkg/netcat/config.go
@@ -150,7 +150,7 @@ func (c *Config) Address() (string, error) {
 				return c.Host + ":" + strconv.FormatUint(port, 10), nil
 			}
 
-			return c.Host + ":" + strconv.FormatUint(c.Port, 10), nil
+			return net.JoinHostPort(c.Host, strconv.FormatUint(c.Port, 10)), nil
 		}
 	case CONNECTION_MODE_LISTEN:
 		var address string

--- a/pkg/netcat/config.go
+++ b/pkg/netcat/config.go
@@ -181,7 +181,7 @@ func (c *Config) Address() (string, error) {
 		if c.ProtocolOptions.SocketType == SOCKET_TYPE_UNIX || c.ProtocolOptions.SocketType == SOCKET_TYPE_UDP_UNIX {
 			return address, nil
 		}
-		return address + ":" + strconv.FormatUint(c.Port, 10), nil
+		return net.JoinHostPort(address, strconv.FormatUint(c.Port, 10)), nil
 	default:
 		return "", fmt.Errorf("invalid connection mode %v", c.ConnectionMode)
 	}

--- a/pkg/netcat/config_test.go
+++ b/pkg/netcat/config_test.go
@@ -268,6 +268,30 @@ func TestAddressListenMode(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name: "Explicit pathname for UNIX domain socket (stream)",
+			config: &Config{
+				ConnectionMode: CONNECTION_MODE_LISTEN,
+				Host:           "/tmp/stream.sock",
+				ProtocolOptions: ProtocolOptions{
+					SocketType: SOCKET_TYPE_UNIX,
+				},
+			},
+			wantAddr: "/tmp/stream.sock",
+			wantErr:  false,
+		},
+		{
+			name: "Explicit pathname for UNIX domain socket (datagram)",
+			config: &Config{
+				ConnectionMode: CONNECTION_MODE_LISTEN,
+				Host:           "/tmp/datagram.sock",
+				ProtocolOptions: ProtocolOptions{
+					SocketType: SOCKET_TYPE_UDP_UNIX,
+				},
+			},
+			wantAddr: "/tmp/datagram.sock",
+			wantErr:  false,
+		},
+		{
 			name: "Unsupported Socket Type",
 			config: &Config{
 				ConnectionMode: CONNECTION_MODE_LISTEN,

--- a/pkg/netcat/config_test.go
+++ b/pkg/netcat/config_test.go
@@ -206,6 +206,19 @@ func TestAddressListenMode(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name: "TCPv6 Listen with valid host",
+			config: &Config{
+				ConnectionMode: CONNECTION_MODE_LISTEN,
+				Host:           "::1",
+				Port:           8080,
+				ProtocolOptions: ProtocolOptions{
+					SocketType: SOCKET_TYPE_TCP,
+				},
+			},
+			wantAddr: "[::1]:8080",
+			wantErr:  false,
+		},
+		{
 			name: "TCPv4 Listen with valid host and default port",
 			config: &Config{
 				ConnectionMode: CONNECTION_MODE_LISTEN,
@@ -215,6 +228,18 @@ func TestAddressListenMode(t *testing.T) {
 				},
 			},
 			wantAddr: "127.0.0.1:0", // Assuming default port is 0 when not specified
+			wantErr:  false,
+		},
+		{
+			name: "TCPv6 Listen with valid host and default port",
+			config: &Config{
+				ConnectionMode: CONNECTION_MODE_LISTEN,
+				Host:           "::1",
+				ProtocolOptions: ProtocolOptions{
+					SocketType: SOCKET_TYPE_TCP,
+				},
+			},
+			wantAddr: "[::1]:0", // Assuming default port is 0 when not specified
 			wantErr:  false,
 		},
 		{
@@ -253,7 +278,7 @@ func TestAddressListenMode(t *testing.T) {
 					IPType:     IP_V6,
 				},
 			},
-			wantAddr: fmt.Sprintf("%s:%d", DEFAULT_IPV6_ADDRESS, DEFAULT_PORT),
+			wantAddr: fmt.Sprintf("[%s]:%d", DEFAULT_IPV6_ADDRESS, DEFAULT_PORT),
 			wantErr:  false,
 		},
 		{

--- a/pkg/netcat/config_test.go
+++ b/pkg/netcat/config_test.go
@@ -193,7 +193,7 @@ func TestAddressListenMode(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name: "TCP Listen with valid host",
+			name: "TCPv4 Listen with valid host",
 			config: &Config{
 				ConnectionMode: CONNECTION_MODE_LISTEN,
 				Host:           "127.0.0.1",
@@ -206,7 +206,7 @@ func TestAddressListenMode(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name: "TCP Listen with valid host and default port",
+			name: "TCPv4 Listen with valid host and default port",
 			config: &Config{
 				ConnectionMode: CONNECTION_MODE_LISTEN,
 				Host:           "127.0.0.1",
@@ -227,7 +227,7 @@ func TestAddressListenMode(t *testing.T) {
 					IPType:     IP_V4_V6,
 				},
 			},
-			wantAddr: DEFAULT_IPV4_ADDRESS + fmt.Sprintf(":%d", DEFAULT_PORT),
+			wantAddr: fmt.Sprintf("%s:%d", DEFAULT_IPV4_ADDRESS, DEFAULT_PORT),
 			wantErr:  false,
 		},
 		{
@@ -240,7 +240,7 @@ func TestAddressListenMode(t *testing.T) {
 					IPType:     IP_V4,
 				},
 			},
-			wantAddr: DEFAULT_IPV4_ADDRESS + fmt.Sprintf(":%d", DEFAULT_PORT),
+			wantAddr: fmt.Sprintf("%s:%d", DEFAULT_IPV4_ADDRESS, DEFAULT_PORT),
 			wantErr:  false,
 		},
 		{
@@ -253,7 +253,7 @@ func TestAddressListenMode(t *testing.T) {
 					IPType:     IP_V6,
 				},
 			},
-			wantAddr: DEFAULT_IPV6_ADDRESS + fmt.Sprintf(":%d", DEFAULT_PORT),
+			wantAddr: fmt.Sprintf("%s:%d", DEFAULT_IPV6_ADDRESS, DEFAULT_PORT),
 			wantErr:  false,
 		},
 		{

--- a/pkg/netcat/config_test.go
+++ b/pkg/netcat/config_test.go
@@ -96,6 +96,43 @@ func TestAddressConnectMode(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name: "TCPv4 Portscan",
+			config: &Config{
+				ConnectionMode: CONNECTION_MODE_CONNECT,
+				Host:           "127.0.0.1",
+				Port:           1234,
+				ConnectionModeOptions: ConnectModeOptions{
+					ScanPorts:   true,
+					CurrentPort: 2345,
+					EndPort:     3456,
+				},
+				ProtocolOptions: ProtocolOptions{
+					SocketType: SOCKET_TYPE_TCP,
+				},
+			},
+			wantAddr: "127.0.0.1:2345",
+			wantErr:  false,
+		},
+		{
+			name: "TCPv6 Portscan",
+			config: &Config{
+				ConnectionMode: CONNECTION_MODE_CONNECT,
+				Host:           "::1",
+				Port:           1234,
+				ConnectionModeOptions: ConnectModeOptions{
+					ScanPorts:   true,
+					CurrentPort: 2345,
+					EndPort:     3456,
+				},
+				ProtocolOptions: ProtocolOptions{
+					SocketType: SOCKET_TYPE_TCP,
+				},
+			},
+			wantAddr: "[::1]:2345",
+			wantErr:  false,
+		},
+
+		{
 			name: "TCP Connect with no DNS host failing",
 			config: &Config{
 				ConnectionMode: CONNECTION_MODE_CONNECT,

--- a/pkg/netcat/config_test.go
+++ b/pkg/netcat/config_test.go
@@ -38,7 +38,7 @@ func TestAddressConnectMode(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name: "TCP Connect with valid host",
+			name: "TCPv4 Connect with valid host",
 			config: &Config{
 				ConnectionMode: CONNECTION_MODE_CONNECT,
 				Host:           "127.0.0.1",
@@ -51,7 +51,7 @@ func TestAddressConnectMode(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name: "TCP Connect with no DNS host",
+			name: "TCPv4 Connect with no DNS host",
 			config: &Config{
 				ConnectionMode: CONNECTION_MODE_CONNECT,
 				Host:           "127.0.0.1",
@@ -82,7 +82,7 @@ func TestAddressConnectMode(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "TCP Connect with valid host and default port",
+			name: "TCPv4 Connect with valid host and default port",
 			config: &Config{
 				ConnectionMode: CONNECTION_MODE_CONNECT,
 				Host:           "127.0.0.1",
@@ -132,7 +132,7 @@ func TestAddressConnectMode(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name: "SCTP",
+			name: "SCTPv4",
 			config: &Config{
 				Host:           "127.0.0.1",
 				Port:           8080,

--- a/pkg/netcat/config_test.go
+++ b/pkg/netcat/config_test.go
@@ -193,7 +193,7 @@ func TestAddressListenMode(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name: "TCP Connect with valid host",
+			name: "TCP Listen with valid host",
 			config: &Config{
 				ConnectionMode: CONNECTION_MODE_LISTEN,
 				Host:           "127.0.0.1",
@@ -206,7 +206,7 @@ func TestAddressListenMode(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name: "TCP Connect with valid host and default port",
+			name: "TCP Listen with valid host and default port",
 			config: &Config{
 				ConnectionMode: CONNECTION_MODE_LISTEN,
 				Host:           "127.0.0.1",

--- a/pkg/netcat/config_test.go
+++ b/pkg/netcat/config_test.go
@@ -51,6 +51,19 @@ func TestAddressConnectMode(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name: "TCPv6 Connect with valid host",
+			config: &Config{
+				ConnectionMode: CONNECTION_MODE_CONNECT,
+				Host:           "::1",
+				Port:           8080,
+				ProtocolOptions: ProtocolOptions{
+					SocketType: SOCKET_TYPE_TCP,
+				},
+			},
+			wantAddr: "[::1]:8080",
+			wantErr:  false,
+		},
+		{
 			name: "TCPv4 Connect with no DNS host",
 			config: &Config{
 				ConnectionMode: CONNECTION_MODE_CONNECT,
@@ -64,6 +77,22 @@ func TestAddressConnectMode(t *testing.T) {
 				},
 			},
 			wantAddr: "127.0.0.1:8080",
+			wantErr:  false,
+		},
+		{
+			name: "TCPv6 Connect with no DNS host",
+			config: &Config{
+				ConnectionMode: CONNECTION_MODE_CONNECT,
+				Host:           "::1",
+				Port:           8080,
+				ProtocolOptions: ProtocolOptions{
+					SocketType: SOCKET_TYPE_TCP,
+				},
+				Misc: MiscOptions{
+					NoDNS: true,
+				},
+			},
+			wantAddr: "[::1]:8080",
 			wantErr:  false,
 		},
 		{
@@ -91,6 +120,18 @@ func TestAddressConnectMode(t *testing.T) {
 				},
 			},
 			wantAddr: "127.0.0.1:0", // Assuming default port is 0 when not specified
+			wantErr:  false,
+		},
+		{
+			name: "TCPv6 Connect with valid host and default port",
+			config: &Config{
+				ConnectionMode: CONNECTION_MODE_CONNECT,
+				Host:           "::1",
+				ProtocolOptions: ProtocolOptions{
+					SocketType: SOCKET_TYPE_TCP,
+				},
+			},
+			wantAddr: "[::1]:0", // Assuming default port is 0 when not specified
 			wantErr:  false,
 		},
 
@@ -142,6 +183,18 @@ func TestAddressConnectMode(t *testing.T) {
 				},
 			},
 			wantAddr: "127.0.0.1:8080",
+		},
+		{
+			name: "SCTPv6",
+			config: &Config{
+				Host:           "::1",
+				Port:           8080,
+				ConnectionMode: CONNECTION_MODE_CONNECT,
+				ProtocolOptions: ProtocolOptions{
+					SocketType: SOCKET_TYPE_SCTP,
+				},
+			},
+			wantAddr: "[::1]:8080",
 		},
 		{
 			name: "VSOCK",

--- a/pkg/netcat/const.go
+++ b/pkg/netcat/const.go
@@ -17,7 +17,7 @@ const (
 	DEFAULT_SHELL           = "/bin/sh"
 	DEFAULT_UNIX_SOCKET     = "/tmp/netcat.sock"
 	DEFAULT_IPV4_ADDRESS    = "0.0.0.0"
-	DEFAULT_IPV6_ADDRESS    = "[::]"
+	DEFAULT_IPV6_ADDRESS    = "::"
 	DEFAULT_WAIT            = time.Duration(10) * time.Second
 )
 


### PR DESCRIPTION
Run netstat in a VM, and verify its output with a selection of string matchers.

Restrict the integration test's building to the logical conjunction of:
- the build restriction used in "cmds/core/netstat" files,
- the build restriction used in "integration/generic-tests" files.